### PR TITLE
Change shader version from 130 to 120 to be compatible with MacOS

### DIFF
--- a/src/main/resources/assets/eternalsingularity/shader/cosmic.frag
+++ b/src/main/resources/assets/eternalsingularity/shader/cosmic.frag
@@ -1,4 +1,4 @@
-#version 130
+#version 120
 
 #define M_PI 3.1415926535897932384626433832795
 
@@ -20,6 +20,10 @@ uniform float opacity;
 uniform mat2 cosmicuvs[cosmiccount];
 
 varying vec3 position;
+
+float rand2d(vec2 x) {
+    return fract(sin(mod(dot(x, vec2(12.9898, 78.233)), 3.14)) * 43758.5453);
+}
 
 mat4 rotationMatrix(vec3 axis, float angle)
 {
@@ -73,9 +77,9 @@ void main (void)
 	
 		// get semi-random stuff
 		int j = i + 7;
-		float rand1 = (j * j * 4321 + j * 8) * 2.0F;
+		float rand1 = (j * j * 4321 + j * 8) * 2.0;
 		int k = j + 1;
-		float rand2 = (k * k * k * 239 + k * 37) * 3.6F;
+		float rand2 = (k * k * k * 239 + k * 37) * 3.6;
 		float rand3 = rand1 * 347.4 + rand2 * 63.4;
 		
 		// random rotation matrix by random rotation around random axis
@@ -101,8 +105,7 @@ void main (void)
 		int tv = int(mod(floor(v*uvtiles),uvtiles)); 
 		
 		// get pseudorandom variants
-		int position = ((1777541 * tu) + (7649689 * tv) + (3612703 * (i+31)) + 1723609 ) ^ 50943779;
-		int symbol = int(mod(position, cosmicoutof));
+		int symbol = int(rand2d(vec2(tu, tv + i * 10.0)) * cosmicoutof);
 		int rotation = int(mod(pow(tu,float(tv)) + tu + 3 + tv*i, 8));
 		bool flip = false;
 		if (rotation >= 4) {


### PR DESCRIPTION
Same problem as https://github.com/GTNewHorizons/Avaritia/pull/24.

Crash on startup:
```
Description: Initializing game

org.lwjgl.opengl.OpenGLException: Invalid value (1281)
    at org.lwjgl.opengl.Util.checkGLError(Util.java:59)
    at org.lwjgl.opengl.ARBShaderObjects.glAttachObjectARB(ARBShaderObjects.java:159)
    at singulariteam.eternalsingularity.render.ShaderHelper.createProgram(ShaderHelper.java:77)
    at singulariteam.eternalsingularity.render.ShaderHelper.initShaders(ShaderHelper.java:27)
    at singulariteam.eternalsingularity.proxy.ClientProxy.init(ClientProxy.java:16)
    at singulariteam.eternalsingularity.EternalSingularityMod.init(EternalSingularityMod.java:49)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at cpw.mods.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:532)
    at sun.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```