### PR TITLE
Workaround for world time error in shader

### DIFF
--- a/src/main/java/singulariteam/eternalsingularity/render/CosmicRenderStuffs.java
+++ b/src/main/java/singulariteam/eternalsingularity/render/CosmicRenderStuffs.java
@@ -40,6 +40,9 @@ public class CosmicRenderStuffs {
                     scale = 25.0f;
                 }
 
+                int time2 = ARBShaderObjects.glGetUniformLocationARB(shader, "time2");
+                ARBShaderObjects.glUniform1fARB(time2, mc.thePlayer.ticksExisted);
+
                 int x = ARBShaderObjects.glGetUniformLocationARB(shader, "yaw");
                 ARBShaderObjects.glUniform1fARB(x, yaw);
 

--- a/src/main/resources/assets/eternalsingularity/shader/cosmic.frag
+++ b/src/main/resources/assets/eternalsingularity/shader/cosmic.frag
@@ -8,7 +8,7 @@ const int cosmicoutof = 101;
 uniform sampler2D texture0;
 uniform vec3 lightlevel;
 
-uniform int time;
+uniform float time2;
 
 uniform float yaw;
 uniform float pitch;
@@ -32,31 +32,32 @@ mat4 rotationMatrix(vec3 axis, float angle)
     float s = sin(angle);
     float c = cos(angle);
     float oc = 1.0 - c;
-    
+
     return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,
                 oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,  0.0,
                 oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c,           0.0,
                 0.0,                                0.0,                                0.0,                                1.0);
 }
 
-void main (void) 
+void main (void)
 {
     vec4 light = gl_Color;
     vec4 mask = texture2D(texture0, gl_TexCoord[0].xy);
     light.rgb *= lightlevel;
-    
+    float correctTime = mod(time2,12000);
+
     float oneOverExternalScale = 1.0/externalScale;
-    
+
     int uvtiles = 16;
-    
+
     // background colour
     vec4 col = vec4(0.1,0.0,0.0,1.0);
-    
-    float pulse = mod(time,400)/400.0;
-    
+
+    float pulse = mod(correctTime,400)/400.0;
+
     col.g = sin(pulse*M_PI*2) * 0.075 + 0.225;
     col.b = cos(pulse*M_PI*2) * 0.05 + 0.3;
-    
+
     // get ray from camera to fragment
     vec4 dir = normalize(vec4( -position, 0));
 
@@ -64,46 +65,46 @@ void main (void)
 	float sb = sin(pitch);
 	float cb = cos(pitch);
 	dir = normalize(vec4(dir.x, dir.y * cb - dir.z * sb, dir.y * sb + dir.z * cb, 0));
-	
+
 	float sa = sin(-yaw);
 	float ca = cos(-yaw);
 	dir = normalize(vec4(dir.z * sa + dir.x * ca, dir.y, dir.z * ca - dir.x * sa, 0));
-	
+
 	vec4 ray;
-	
+
 	// draw the layers
 	for (int i=0; i<16; i++) {
 		int mult = 16-i;
-	
+
 		// get semi-random stuff
 		int j = i + 7;
 		float rand1 = (j * j * 4321 + j * 8) * 2.0;
 		int k = j + 1;
 		float rand2 = (k * k * k * 239 + k * 37) * 3.6;
 		float rand3 = rand1 * 347.4 + rand2 * 63.4;
-		
+
 		// random rotation matrix by random rotation around random axis
 		vec3 axis = normalize(vec3(sin(rand1), sin(rand2) , cos(rand3)));
-		
+
 		// apply
 		ray = dir * rotationMatrix(axis, mod(rand3, 2*M_PI));
-		
+
 		// calcuate the UVs from the final ray
 		float rawu = 0.5 + (atan(ray.z,ray.x)/(2*M_PI));
 		float rawv = 0.5 + (asin(ray.y)/M_PI);
-		
+
 		// get UV scaled for layers and offset by time;
 		float scale = mult*0.5 + 2.75;
 		float u = rawu * scale * externalScale;
 		//float v = (rawv + time * 0.00006) * scale * 0.6;
-		float v = (rawv + time * 0.0002 * oneOverExternalScale) * scale * 0.6 * externalScale;
-		
+		float v = (rawv + correctTime * 0.0002 * oneOverExternalScale) * scale * 0.6 * externalScale;
+
 		vec2 tex = vec2( u, v );
-		
+
 		// tile position of the current uv
 		int tu = int(mod(floor(u*uvtiles),uvtiles));
-		int tv = int(mod(floor(v*uvtiles),uvtiles)); 
-		
+		int tv = int(mod(floor(v*uvtiles),uvtiles));
+
 		// get pseudorandom variants
 		int symbol = int(rand2d(vec2(tu, tv + i * 10.0)) * cosmicoutof);
 		int rotation = int(mod(pow(tu,float(tv)) + tu + 3 + tv*i, 8));
@@ -112,21 +113,21 @@ void main (void)
 			rotation -= 4;
 			flip = true;
 		}
-		
+
 		// if it's an icon, then add the colour!
 		if (symbol >= 0 && symbol < cosmiccount) {
-			
+
 			vec2 cosmictex = vec2(1.0,1.0);
 			vec4 tcol = vec4(1.0,0.0,0.0,1.0);
-			
+
 			// get uv within the tile
 			float ru = clamp(mod(u,1.0)*uvtiles - tu, 0.0, 1.0);
 			float rv = clamp(mod(v,1.0)*uvtiles - tv, 0.0, 1.0);
-			
+
 			if (flip) {
 				ru = 1.0 - ru;
 			}
-			
+
 			float oru = ru;
 			float orv = rv;
 
@@ -141,7 +142,7 @@ void main (void)
 				oru = rv;
 				orv = 1.0-ru;
 			}
-			
+
 			// get the iicon uvs for the tile
 			float umin = cosmicuvs[symbol][0][0];
 			float umax = cosmicuvs[symbol][1][0];
@@ -151,17 +152,17 @@ void main (void)
 			// interpolate based on tile uvs
 			cosmictex.x = umin * (1.0-oru) + umax * oru;
 			cosmictex.y = vmin * (1.0-orv) + vmax * orv;
-			
+
 			tcol = texture2D(texture0, cosmictex);
-			
+
 			// set the alpha, blending out at the bunched ends
 			float a = tcol.r * (0.5 + (1.0/mult) * 1.0) * (1.0-smoothstep(0.15, 0.48, abs(rawv-0.5)));
-			
+
 			// get fancy colours
 			float r = (mod(rand1, 29.0)/29.0) * 0.3 + 0.4;
 	    	float g = (mod(rand2, 35.0)/35.0) * 0.4 + 0.6;
 	    	float b = (mod(rand1, 17.0)/17.0) * 0.3 + 0.7;
-			
+
 			// mix the colours
 			//col = col*(1-a) + vec4(r,g,b,1)*a;
 			col = col + vec4(r,g,b,1)*a;
@@ -171,11 +172,11 @@ void main (void)
 	// apply lighting
     vec3 shade = light.rgb * (lightmix) + vec3(1.0-lightmix,1.0-lightmix,1.0-lightmix);
     col.rgb *= shade;
-    
+
     // apply mask
     col.a *= mask.r * opacity;
-    
+
 	col = clamp(col,0.0,1.0);
-	
+
     gl_FragColor = col;
 }


### PR DESCRIPTION
A workaround to fix the non optifine related part of https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/12693
This uses the client player ticks existed count as a new uniform value instead of the server world time's progression for the animation and color. It then modulos the value to cycle every 12000 ticks and prevent an oversized value from being passed on.

This could also be done to the original server world time uniform value, however it results in a less consistent amimation.


